### PR TITLE
加速度とジャイロの相補フィルターを使用した姿勢制御&csv出力用のコードです

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rocket_Attitude_control
+# Rocket_Attitude_Control
 
 ラズパイでロケットの姿勢制御をするためのコード
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# rocket_attitude_control

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Rocket_Attitude_control
+
+ラズパイでロケットの姿勢制御をするためのコード
+
+# Features
+
+[pipenv](https://github.com/pypa/pipenv) で環境を作成します。pipenv の使い方は[公式ドキュメント](https://pipenv-ja.readthedocs.io/ja/translate-ja/)を参照してください。
+
+```shell
+pip install pipenv
+pipenv install --python 3.7.2
+```
+
+# Requirement
+
+* Python 3.7.2
+* pigpio 1.44
+* libi2c-dev
+* smbus
+
+# Installation
+
+Install package with pipenv command.
+
+```bash
+pipenv install pigpio~=1.44
+pipenv install smbus
+pipenv install libi2c-dev
+```
+
+# Usage
+
+Run "attitude_control.py"
+
+```bash
+git clone https://github.com/kure-kosen-water-rocket/rocket_attitude_control
+pipenv shell
+sudo pigpiod
+python attitude_control.py
+```
+
+# Note
+
+ラズベリーパイ上でのみ動作確認済みです

--- a/attitude_control.py
+++ b/attitude_control.py
@@ -1,0 +1,124 @@
+import smbus
+import math
+import time
+import csv
+import pigpio
+from pigpio import pi
+
+DEV_ADDR = 0x68
+ACCEL_XOUT = 0x3b
+ACCEL_YOUT = 0x3d
+ACCEL_ZOUT = 0x3f
+TEMP_OUT = 0x41
+GYRO_XOUT = 0x43
+GYRO_YOUT = 0x45
+GYRO_ZOUT = 0x47
+PWR_MGMT_1 = 0x6b
+PWR_MGMT_2 = 0x6c
+
+bus = smbus.SMBus(1)
+bus.write_byte_data(DEV_ADDR, PWR_MGMT_1, 0)
+
+def read_byte(adr):
+    return bus.read_byte_data(DEV_ADDR, adr)
+
+def read_word(adr):
+    high = bus.read_byte_data(DEV_ADDR, adr) 
+    low  = bus.read_byte_data(DEV_ADDR, adr+1)
+    val  = (high << 8) + low
+    return val
+
+def read_word_sensor(adr):
+    val  = read_word(adr)
+    if (val >= 0x8000):
+        return -((65535 - val) + 1)
+    else:
+        return val
+
+def get_gyro_data_lsb():               #角速度(ジャイロ)データ取得
+    x = read_word_sensor(GYRO_XOUT)
+    y = read_word_sensor(GYRO_YOUT)
+    z = read_word_sensor(GYRO_ZOUT)
+    return [x, y, z]
+
+def get_gyro_data_deg():
+    x,y,z = get_gyro_data_lsb()
+    x = x / 1310
+    y = y / 1310
+    z = z / 1310
+    return [x, y, z]
+
+def get_accel_data_lsb():              #加速度データ取得
+    x = read_word_sensor(ACCEL_XOUT)
+    y = read_word_sensor(ACCEL_YOUT)
+    z = read_word_sensor(ACCEL_ZOUT)
+    return [x, y, z]
+
+def get_accel_data_g():
+    x,y,z = get_accel_data_lsb()
+    x = x / 16384.0
+    y = y / 16384.0
+    z = z / 16384.0
+    return [x, y, z]
+
+class Servo_Class:
+    def __init__(self, Pin):
+        self.pi = pi()
+        self.mPin = Pin
+        self.pi.set_mode(self.mPin, pigpio.OUTPUT)
+
+    def SetPos(self, degree):
+        duty = int(((12-2.5)/180*degree+2.5)*10000)
+        self.pi.hardware_PWM(self.mPin, 50, duty)
+
+    def Cleanup(self):
+        self.pi.hardware_PWM(self.mPin, 50, self.SetPos(0))
+        time.sleep(1)
+        self.pi.set_mode(self.mPin, pigpio.INPUT)
+        self.pi.stop()
+
+dt = 0 #初期値の設定
+total_time = 0
+total_counts = 0
+calculate_time= 50
+old_y_gyro = 0
+old_angle = 0
+fieldnames = ['x_accel', 'y_accel', 'z_accel', 'x_gyro', 'y_gyro', 'z_gyro', 'dt']
+
+Servo = Servo_Class(Pin=18) #Servo_Classのインスタンス化
+Servo.SetPos(90) #初期位置を90度に設定
+
+while 1:
+    start = time.time() #ループ中にかかる時間を計測開始
+    
+    x_gyro,  y_gyro,  z_gyro  = get_gyro_data_deg()
+    x_accel, y_accel, z_accel = get_accel_data_g()
+
+    y_gyro = y_gyro*0.3
+    y_angle = math.atan2(x_accel , math.sqrt(y_accel**2 + z_accel**2))#姿勢角の算出
+    k = 0.2 * (65536**-((abs(x_accel))/10)) #加速度が増加→加速度から得られる角度の比重を小さくしていく係数k
+    y_angle = (((1-k) * (old_angle + (((old_y_gyro + y_gyro)* dt) / 2)) + ((k* y_angle)))) #加速度とジャイロの相補フィルター
+    old_angle = y_angle #角速度で足していくため一つ前の角度が必要
+    old_y_gyro = y_gyro #台形うよう積分用に一つ前の角速度を残しておく
+
+    if int(total_time) % 1 == 0: #dt秒毎に処理を実行
+        if 86-int(math.degrees(y_angle)) < 180 and 86-int(math.degrees(y_angle)) > 0: #0度~180度の時のみ動作
+            Servo.SetPos(86 - int(math.degrees(y_angle))) #初ｓ期位置は90度からなので(86は調整した)
+
+    with open('measurement.csv', 'a') as measurement_file:
+        writer = csv.DictWriter(measurement_file, fieldnames=fieldnames)
+        writer.writerow({'x_accel':x_accel,
+                         'y_accel':y_accel,
+                         'z_accel':z_accel,
+                         'x_gyro' :x_gyro ,
+                         'y_gyro' :y_gyro ,
+                         'z_gyro' :z_gyro ,
+                         'dt'     :dt })
+
+    if int(total_time) == int(calculate_time): #計測時間がtotal_timeに達したらプログラム終了
+        break
+
+    dt = time.time() - start #ループにかかる時間を微小時間dtに代入
+    total_time += dt
+
+Servo_right.Cleanup()

--- a/attitude_control.py
+++ b/attitude_control.py
@@ -28,16 +28,18 @@ while 1:
     data_logs.append([x_accel, y_accel, z_accel, x_gyro, y_gyro, z_gyro, dt])
 
     y_angle = math.atan2(x_accel , math.sqrt(y_accel**2 + z_accel**2))#姿勢角の算出
-    k = 0.2 * (65536**-((abs(x_accel))/10)) #加速度が増加→加速度から得られる角度の比重を小さくしていく係数k
-    y_angle = (((1-k) * (old_angle + (((old_y_gyro + y_gyro)* dt) / 2)) + ((k* y_angle)))) #加速度とジャイロの相補フィルター
+    k = 0.2 * (65536**-(abs(x_accel)/10)) #加速度が増加→加速度から得られる角度の比重を小さくしていく係数k
+    y_angle = (((1-k) * (old_angle + ((old_y_gyro + y_gyro)* dt / 2)) + k* y_angle)) #加速度とジャイロの相補フィルター
     old_angle = y_angle #角度の変化量を足していくため一つ前の角度が必要
     old_y_gyro = y_gyro #台形積分用に一つ前の角速度を残しておく
 
-    if int(total_time) % 1 == 0: #dt秒毎に処理を実行
-        if 86-int(math.degrees(y_angle)) < 180 and 86-int(math.degrees(y_angle)) > 0: #0度~180度の時のみ動作
-            Servo.set_position(86 - int(math.degrees(y_angle))) #初期位置は90度からなので(86は調整した値)
+    adjust_y_angle = 86-int(math.degrees(y_angle)) #初期位置は90度からなので(86は調整した値)
 
-    if int(total_time) > int(CALC_TIME): #計測時間がtotal_timeに達したらプログラム終了
+    if int(total_time) % 1 == 0: #dt秒毎に処理を実行
+        if adjust_y_angle < 180 and adjust_y_angle > 0: #0度~180度の時のみ動作
+            Servo.set_position(adjust_y_angle)
+
+    if CALC_TIME < int(total_time): #計測時間がtotal_timeに達したらプログラム終了
         break
 
     dt = time.time() - start #ループにかかる時間を微小時間dtに代入

--- a/attitude_control.py
+++ b/attitude_control.py
@@ -37,7 +37,8 @@ while 1:
         if 86-int(math.degrees(y_angle)) < 180 and 86-int(math.degrees(y_angle)) > 0: #0度~180度の時のみ動作
             Servo.set_position(86 - int(math.degrees(y_angle))) #初期位置は90度からなので(86は調整した値)
 
-    if int(total_time) > int(CALC_TIME): #計測時間がtotal_timeに達したらプログラム終了
+    #計測時間がtotal_timeに達したらプログラム終了
+    if CALC_TIME < int(total_time):
         break
 
     dt = time.time() - start #ループにかかる時間を微小時間dtに代入

--- a/attitude_control.py
+++ b/attitude_control.py
@@ -68,7 +68,7 @@ total_time = 0
 old_y_gyro = 0
 old_angle = 0
 fieldnames = ['x_accel', 'y_accel', 'z_accel', 'x_gyro', 'y_gyro', 'z_gyro', 'dt']
-data_log = []
+data_logs = []
 CALC_TIME = 5
 
 Servo = ServoController(Pin=18)
@@ -80,7 +80,7 @@ while 1:
     x_gyro,  y_gyro,  z_gyro  = get_gyro_data_deg()
     x_accel, y_accel, z_accel = get_accel_data_g()
 
-    data_log.append([x_accel, y_accel, z_accel, x_gyro, y_gyro, z_gyro, dt])
+    data_logs.append([x_accel, y_accel, z_accel, x_gyro, y_gyro, z_gyro, dt])
 
     y_angle = math.atan2(x_accel , math.sqrt(y_accel**2 + z_accel**2))#姿勢角の算出
     k = 0.2 * (65536**-((abs(x_accel))/10)) #加速度が増加→加速度から得られる角度の比重を小さくしていく係数k
@@ -103,4 +103,4 @@ Servo.clean_up()
 with open('measurement.csv', 'w') as measurement_file:
     writer = csv.writer(measurement_file, lineterminator='\n')
     writer.writerow(fieldnames)
-    writer.writerows(data_log)
+    writer.writerows(data_logs)

--- a/attitude_control.py
+++ b/attitude_control.py
@@ -12,7 +12,7 @@ old_y_gyro = 0
 old_angle = 0
 fieldnames = ['x_accel', 'y_accel', 'z_accel', 'x_gyro', 'y_gyro', 'z_gyro', 'dt']
 data_logs = []
-CALC_TIME = 5
+CALC_TIME = 20
 
 mpu6050 = Mpu6050()
 
@@ -22,8 +22,8 @@ Servo.set_position(90) #初期位置を90度に設定
 while 1:
     start = time.time() #ループ中にかかる時間を計測開始
 
-    x_gyro,  y_gyro,  z_gyro  = mpu6050.get_gyro_data_deg()
-    x_accel, y_accel, z_accel = mpu6050.get_accel_data_g()
+    x_gyro,  y_gyro,  z_gyro  = mpu6050.gyro_lsb()
+    x_accel, y_accel, z_accel = mpu6050.accel_lsb()
 
     data_logs.append([x_accel, y_accel, z_accel, x_gyro, y_gyro, z_gyro, dt])
 

--- a/attitude_control.py
+++ b/attitude_control.py
@@ -5,49 +5,71 @@ from servo import ServoController
 from mpu6050 import Mpu6050
 
 
-#初期値の設定
+# 初期値の設定
 dt = 0
-total_time = 0
-old_y_gyro = 0
-old_angle = 0
-fieldnames = ['x_accel', 'y_accel', 'z_accel', 'x_gyro', 'y_gyro', 'z_gyro', 'dt']
-data_logs = []
-CALC_TIME = 20
+current_time = 0
+prev_gyro = 0
+prev_angle = 0
+fieldnames = ['accel_x', 'accel_y', 'accel_z',
+              'gyro_x', 'gyro_y', 'gyro_y', 'dt']
+instrumentation_logs = []
+CALC_TIME = 50
+
+
+def find_angle_in_acceleration(accel_x, accel_y, accel_z):
+    accel_only_angle = math.atan2(
+        accel_x, math.sqrt(accel_y ** 2 + accel_z ** 2))
+    return accel_only_angle
+
+
+def complement_filter_coefficient(accel_x):
+    factor = 0.2 * (65536 ** -(abs(accel_x) / 10))  # 加速度の大きさによって変化する係数
+    return factor
+
+
+def complement_filter(accel_only_angle, y_gyro, prev_angle, prev_gyro, factor):
+    real_angle = (1 - factor) * (prev_angle + math.radians((prev_gyro +
+                                                            y_gyro) * dt / 2)) + factor * accel_only_angle  # 相補フィルター
+    prev_angle = real_angle  # 角度の変化量を足していくため一つ前の角度が必要
+    prev_gyro = y_gyro  # 台形積分用に一つ前の角速度を残しておく
+    adjust_angle = 90 - int(math.degrees(real_angle))  # -90度~90度の範囲を0度~180度に変換
+    return [adjust_angle, prev_angle, prev_gyro]
+
 
 mpu6050 = Mpu6050()
 
-Servo = ServoController(Pin=18)
-Servo.set_position(90) #初期位置を90度に設定
+servo = ServoController(Pin=18)  # 物理ピン番号
+servo.set_position(90)  # 初期位置を90度に設定
 
 while 1:
-    start = time.time() #ループ中にかかる時間を計測開始
+    start = time.time()  # ループ中にかかる時間を計測開始
 
-    x_gyro,  y_gyro,  z_gyro  = mpu6050.gyro_lsb()
-    x_accel, y_accel, z_accel = mpu6050.accel_lsb()
+    gyro_x,  gyro_y,  gyro_z = mpu6050.gyro_lsb()
+    accel_x, accel_y, accel_z = mpu6050.accel_lsb()
 
-    data_logs.append([x_accel, y_accel, z_accel, x_gyro, y_gyro, z_gyro, dt])
+    instrumentation_logs.append(
+        [accel_x, accel_y, accel_z, gyro_x, gyro_y, gyro_z, dt])
 
-    y_angle = math.atan2(x_accel , math.sqrt(y_accel**2 + z_accel**2))#姿勢角の算出
-    k = 0.2 * (65536**-(abs(x_accel)/10)) #加速度が増加→加速度から得られる角度の比重を小さくしていく係数k
-    y_angle = (((1-k) * (old_angle + math.radians(((old_y_gyro + y_gyro)* dt) / 2)) + k* y_angle)) #加速度とジャイロの相補フィルター
-    old_angle = y_angle #角度の変化量を足していくため一つ前の角度が必要
-    old_y_gyro = y_gyro #台形積分用に一つ前の角速度を残しておく
+    accel_only_angle = find_angle_in_acceleration(accel_x, accel_y, accel_z)
 
-    adjust_y_angle = 90-int(math.degrees(y_angle)) #初期位置は90度からなので
+    factor = complement_filter_coefficient(accel_x)
 
-    if adjust_y_angle < 180 and adjust_y_angle > 0: #センサーが0度~180度の時のみ動作
-        Servo.set_position(adjust_y_angle)
+    adjust_angle, prev_angle, prev_gyro = complement_filter(
+        accel_only_angle, gyro_y, prev_angle, prev_gyro, factor)
 
-    #計測時間がtotal_timeに達したらプログラム終了
-    if CALC_TIME < int(total_time):
+    if adjust_angle < 180 and adjust_angle > 0:  # 0度~180度の時のみ動作
+        servo.set_position(adjust_angle)
+
+    # 計測時間がcurrent_timeに達したらプログラム終了
+    if CALC_TIME < int(current_time):
         break
 
-    dt = time.time() - start #ループにかかる時間を微小時間dtに代入
-    total_time += dt
+    dt = time.time() - start  # ループにかかる時間を微小時間dtに代入
+    current_time += dt
 
-Servo.clean_up()
+servo.clean_up()
 
 with open('measurement.csv', 'w') as measurement_file:
     writer = csv.writer(measurement_file, lineterminator='\n')
     writer.writerow(fieldnames)
-    writer.writerows(data_logs)
+    writer.writerows(instrumentation_logs)

--- a/attitude_control.py
+++ b/attitude_control.py
@@ -33,7 +33,7 @@ while 1:
     old_angle = y_angle #角度の変化量を足していくため一つ前の角度が必要
     old_y_gyro = y_gyro #台形積分用に一つ前の角速度を残しておく
 
-    adjust_y_angle = 90-int(math.degrees(y_angle)) #初期位置は90度からなので(86は調整した値)
+    adjust_y_angle = 90-int(math.degrees(y_angle)) #初期位置は90度からなので
 
     if adjust_y_angle < 180 and adjust_y_angle > 0: #0度~180度の時のみ動作
         Servo.set_position(adjust_y_angle)

--- a/attitude_control.py
+++ b/attitude_control.py
@@ -29,13 +29,13 @@ while 1:
 
     y_angle = math.atan2(x_accel , math.sqrt(y_accel**2 + z_accel**2))#姿勢角の算出
     k = 0.2 * (65536**-(abs(x_accel)/10)) #加速度が増加→加速度から得られる角度の比重を小さくしていく係数k
-    y_angle = (((1-k) * (old_angle + ((old_y_gyro + y_gyro)* dt / 2)) + k* y_angle)) #加速度とジャイロの相補フィルター
+    y_angle = (((1-k) * (old_angle + math.radians(((old_y_gyro + y_gyro)* dt) / 2)) + k* y_angle)) #加速度とジャイロの相補フィルター
     old_angle = y_angle #角度の変化量を足していくため一つ前の角度が必要
     old_y_gyro = y_gyro #台形積分用に一つ前の角速度を残しておく
 
-    adjust_y_angle = 90-int(math.degrees(y_angle)) #初期位置は90度からなので(86は調整した値)
+    adjust_y_angle = 90-int(math.degrees(y_angle)) #初期位置は90度からなので
 
-    if adjust_y_angle < 180 and adjust_y_angle > 0: #0度~180度の時のみ動作
+    if adjust_y_angle < 180 and adjust_y_angle > 0: #センサーが0度~180度の時のみ動作
         Servo.set_position(adjust_y_angle)
 
     #計測時間がtotal_timeに達したらプログラム終了

--- a/attitude_control.py
+++ b/attitude_control.py
@@ -1,4 +1,3 @@
-import smbus
 import math
 import time
 import csv
@@ -104,4 +103,4 @@ Servo.clean_up()
 with open('measurement.csv', 'w') as measurement_file:
     writer = csv.writer(measurement_file, lineterminator='\n')
     writer.writerow(fieldnames)
-    writer.writerows(experiment_log)
+    writer.writerows(data_log)

--- a/attitude_control.py
+++ b/attitude_control.py
@@ -33,11 +33,10 @@ while 1:
     old_angle = y_angle #角度の変化量を足していくため一つ前の角度が必要
     old_y_gyro = y_gyro #台形積分用に一つ前の角速度を残しておく
 
-    adjust_y_angle = 86-int(math.degrees(y_angle)) #初期位置は90度からなので(86は調整した値)
+    adjust_y_angle = 90-int(math.degrees(y_angle)) #初期位置は90度からなので(86は調整した値)
 
-    if int(total_time) % 1 == 0: #dt秒毎に処理を実行
-        if adjust_y_angle < 180 and adjust_y_angle > 0: #0度~180度の時のみ動作
-            Servo.set_position(adjust_y_angle)
+    if adjust_y_angle < 180 and adjust_y_angle > 0: #0度~180度の時のみ動作
+        Servo.set_position(adjust_y_angle)
 
     #計測時間がtotal_timeに達したらプログラム終了
     if CALC_TIME < int(total_time):

--- a/mpu6050.py
+++ b/mpu6050.py
@@ -41,9 +41,9 @@ class Mpu6050:
 
     def gyro_lsb(self):
         x_gyro,y_gyro,z_gyro = self.__load_gyro_sensor()
-        x_gyro /= 131000
-        y_gyro /= 131000
-        z_gyro /= 131000
+        x_gyro /= 131
+        y_gyro /= 131
+        z_gyro /= 131
         return [x_gyro, y_gyro, z_gyro]
 
     #加速度(m/msec)取得
@@ -55,7 +55,8 @@ class Mpu6050:
 
     def accel_lsb(self):
         x_accel,y_accel,z_accel = self.__load_accelerometer()
-        x_accel /= 16384000
-        y_accel /= 16384000
-        z_accel /= 16384000
+        x_accel /= 16384
+        y_accel /= 16384
+        z_accel /= 16384
         return [x_accel, y_accel, z_accel]
+        

--- a/mpu6050.py
+++ b/mpu6050.py
@@ -1,5 +1,6 @@
 from smbus import SMBus
 
+
 class Mpu6050:
 
     def __init__(self):

--- a/mpu6050.py
+++ b/mpu6050.py
@@ -1,7 +1,7 @@
 from smbus import SMBus
 
 
-# ref: https://shizenkarasuzon.hatenablog.com/entry/2019/03/06/114248
+# ref: http://www.widesnow.com/entry/2015/09/10/061128
 DEV_ADDR = 0x68
 ACCEL_XOUT = 0x3b
 ACCEL_YOUT = 0x3d
@@ -33,29 +33,29 @@ class Mpu6050:
             return val
 
     #角速度(ジャイロ)データ取得
-    def __get_gyro_data_lsb(self):
+    def __load_gyro_sensor(self):
         x_gyro = self.__read_word_sensor(GYRO_XOUT)
         y_gyro = self.__read_word_sensor(GYRO_YOUT)
         z_gyro = self.__read_word_sensor(GYRO_ZOUT)
         return [x_gyro, y_gyro, z_gyro]
 
-    def get_gyro_data_deg(self):
-        x_gyro,y_gyro,z_gyro = self.__get_gyro_data_lsb()
-        x_gyro /= 1310
-        y_gyro /= 1310
-        z_gyro /= 1310
+    def gyro_lsb(self):
+        x_gyro,y_gyro,z_gyro = self.__load_gyro_sensor()
+        x_gyro /= 131000
+        y_gyro /= 131000
+        z_gyro /= 131000
         return [x_gyro, y_gyro, z_gyro]
 
     #加速度データ取得
-    def __get_accel_data_lsb(self):
+    def __load_accelerometer(self):
         x_accel = self.__read_word_sensor(ACCEL_XOUT)
         y_accel = self.__read_word_sensor(ACCEL_YOUT)
         z_accel = self.__read_word_sensor(ACCEL_ZOUT)
         return [x_accel, y_accel, z_accel]
 
-    def get_accel_data_g(self):
-        x_accel,y_accel,z_accel = self.__get_accel_data_lsb()
-        x_accel /= 16384.0
-        y_accel /= 16384.0
-        z_accel /= 16384.0
+    def accel_lsb(self):
+        x_accel,y_accel,z_accel = self.__load_accelerometer()
+        x_accel /= 16384000
+        y_accel /= 16384000
+        z_accel /= 16384000
         return [x_accel, y_accel, z_accel]

--- a/mpu6050.py
+++ b/mpu6050.py
@@ -1,0 +1,61 @@
+from smbus import SMBus
+
+class Mpu6050:
+
+    def __init__(self):
+        self.DEV_ADDR = 0x68 #https://shizenkarasuzon.hatenablog.com/entry/2019/03/06/114248
+        self.ACCEL_XOUT = 0x3b
+        self.ACCEL_YOUT = 0x3d
+        self.ACCEL_ZOUT = 0x3f
+        self.TEMP_OUT = 0x41
+        self.GYRO_XOUT = 0x43
+        self.GYRO_YOUT = 0x45
+        self.GYRO_ZOUT = 0x47
+        self.PWR_MGMT_1 = 0x6b
+        self.PWR_MGMT_2 = 0x6c
+        self.bus = SMBus(1)
+        self.bus.write_byte_data(self.DEV_ADDR, self.PWR_MGMT_1, 0)
+
+    def read_byte(self, adr):
+        return self.bus.read_byte_data(self.DEV_ADDR, adr)
+
+    def read_word(self, adr):
+        high = self.bus.read_byte_data(self.DEV_ADDR, adr)
+        low  = self.bus.read_byte_data(self.DEV_ADDR, adr+1)
+        val  = (high << 8) + low
+        return val
+
+    def read_word_sensor(self, adr):
+        val  = self.read_word(adr)
+        if (val >= 0x8000):
+            return -((65535 - val) + 1)
+        else:
+            return val
+
+    #角速度(ジャイロ)データ取得
+    def get_gyro_data_lsb(self):
+        self.x = self.read_word_sensor(self.GYRO_XOUT)
+        self.y = self.read_word_sensor(self.GYRO_YOUT)
+        self.z = self.read_word_sensor(self.GYRO_ZOUT)
+        return [self.x, self.y, self.z]
+
+    def get_gyro_data_deg(self):
+        x,y,z = self.get_gyro_data_lsb()
+        x = self.x / 1310
+        y = self.y / 1310
+        z = self.z / 1310
+        return [x, y, z]
+
+    #加速度データ取得
+    def get_accel_data_lsb(self):
+        self.x = self.read_word_sensor(self.ACCEL_XOUT)
+        self.y = self.read_word_sensor(self.ACCEL_YOUT)
+        self.z = self.read_word_sensor(self.ACCEL_ZOUT)
+        return [self.x, self.y, self.z]
+
+    def get_accel_data_g(self):
+        x,y,z = self.get_accel_data_lsb()
+        x = self.x / 16384.0
+        y = self.y / 16384.0
+        z = self.z / 16384.0
+        return [x, y, z]

--- a/mpu6050.py
+++ b/mpu6050.py
@@ -13,6 +13,7 @@ GYRO_ZOUT = 0x47
 PWR_MGMT_1 = 0x6b
 PWR_MGMT_2 = 0x6c
 
+
 class Mpu6050:
 
     def __init__(self):
@@ -21,42 +22,41 @@ class Mpu6050:
 
     def __read_word(self, adr):
         high = self.bus.read_byte_data(DEV_ADDR, adr)
-        low  = self.bus.read_byte_data(DEV_ADDR, adr+1)
-        val  = (high << 8) + low
+        low = self.bus.read_byte_data(DEV_ADDR, adr+1)
+        val = (high << 8) + low
         return val
 
     def __read_word_sensor(self, adr):
-        val  = self.__read_word(adr)
+        val = self.__read_word(adr)
         if (val >= 0x8000):
             return -((65535 - val) + 1)
         else:
             return val
 
-    #角速度(rad/msec)取得
+    # 角速度(rad/msec)取得
     def __load_gyro_sensor(self):
-        x_gyro = self.__read_word_sensor(GYRO_XOUT)
-        y_gyro = self.__read_word_sensor(GYRO_YOUT)
-        z_gyro = self.__read_word_sensor(GYRO_ZOUT)
-        return [x_gyro, y_gyro, z_gyro]
+        gyro_x = self.__read_word_sensor(GYRO_XOUT)
+        gyro_y = self.__read_word_sensor(GYRO_YOUT)
+        gyro_z = self.__read_word_sensor(GYRO_ZOUT)
+        return [gyro_x, gyro_y, gyro_z]
 
     def gyro_lsb(self):
-        x_gyro,y_gyro,z_gyro = self.__load_gyro_sensor()
-        x_gyro /= 131
-        y_gyro /= 131
-        z_gyro /= 131
-        return [x_gyro, y_gyro, z_gyro]
+        gyro_x, gyro_y, gyro_z = self.__load_gyro_sensor()
+        gyro_x /= 131
+        gyro_y /= 131
+        gyro_z /= 131
+        return [gyro_x, gyro_y, gyro_z]
 
-    #加速度(m/msec)取得
+    # 加速度(m/msec)取得
     def __load_accelerometer(self):
-        x_accel = self.__read_word_sensor(ACCEL_XOUT)
-        y_accel = self.__read_word_sensor(ACCEL_YOUT)
-        z_accel = self.__read_word_sensor(ACCEL_ZOUT)
-        return [x_accel, y_accel, z_accel]
+        accel_x = self.__read_word_sensor(ACCEL_XOUT)
+        accel_y = self.__read_word_sensor(ACCEL_YOUT)
+        accel_z = self.__read_word_sensor(ACCEL_ZOUT)
+        return [accel_x, accel_y, accel_z]
 
     def accel_lsb(self):
-        x_accel,y_accel,z_accel = self.__load_accelerometer()
+        x_accel, y_accel, z_accel = self.__load_accelerometer()
         x_accel /= 16384
         y_accel /= 16384
         z_accel /= 16384
         return [x_accel, y_accel, z_accel]
-        

--- a/mpu6050.py
+++ b/mpu6050.py
@@ -17,45 +17,42 @@ class Mpu6050:
         self.bus = SMBus(1)
         self.bus.write_byte_data(self.DEV_ADDR, self.PWR_MGMT_1, 0)
 
-    def read_byte(self, adr):
-        return self.bus.read_byte_data(self.DEV_ADDR, adr)
-
-    def read_word(self, adr):
+    def __read_word(self, adr):
         high = self.bus.read_byte_data(self.DEV_ADDR, adr)
         low  = self.bus.read_byte_data(self.DEV_ADDR, adr+1)
         val  = (high << 8) + low
         return val
 
-    def read_word_sensor(self, adr):
-        val  = self.read_word(adr)
+    def __read_word_sensor(self, adr):
+        val  = self.__read_word(adr)
         if (val >= 0x8000):
             return -((65535 - val) + 1)
         else:
             return val
 
     #角速度(ジャイロ)データ取得
-    def get_gyro_data_lsb(self):
-        self.x = self.read_word_sensor(self.GYRO_XOUT)
-        self.y = self.read_word_sensor(self.GYRO_YOUT)
-        self.z = self.read_word_sensor(self.GYRO_ZOUT)
+    def __get_gyro_data_lsb(self):
+        self.x = self.__read_word_sensor(self.GYRO_XOUT)
+        self.y = self.__read_word_sensor(self.GYRO_YOUT)
+        self.z = self.__read_word_sensor(self.GYRO_ZOUT)
         return [self.x, self.y, self.z]
 
     def get_gyro_data_deg(self):
-        x,y,z = self.get_gyro_data_lsb()
+        x,y,z = self.__get_gyro_data_lsb()
         x = self.x / 1310
         y = self.y / 1310
         z = self.z / 1310
         return [x, y, z]
 
     #加速度データ取得
-    def get_accel_data_lsb(self):
-        self.x = self.read_word_sensor(self.ACCEL_XOUT)
-        self.y = self.read_word_sensor(self.ACCEL_YOUT)
-        self.z = self.read_word_sensor(self.ACCEL_ZOUT)
+    def __get_accel_data_lsb(self):
+        self.x = self.__read_word_sensor(self.ACCEL_XOUT)
+        self.y = self.__read_word_sensor(self.ACCEL_YOUT)
+        self.z = self.__read_word_sensor(self.ACCEL_ZOUT)
         return [self.x, self.y, self.z]
 
     def get_accel_data_g(self):
-        x,y,z = self.get_accel_data_lsb()
+        x,y,z = self.__get_accel_data_lsb()
         x = self.x / 16384.0
         y = self.y / 16384.0
         z = self.z / 16384.0

--- a/mpu6050.py
+++ b/mpu6050.py
@@ -1,25 +1,26 @@
 from smbus import SMBus
 
 
+DEV_ADDR = 0x68 #https://shizenkarasuzon.hatenablog.com/entry/2019/03/06/114248
+ACCEL_XOUT = 0x3b
+ACCEL_YOUT = 0x3d
+ACCEL_ZOUT = 0x3f
+TEMP_OUT = 0x41
+GYRO_XOUT = 0x43
+GYRO_YOUT = 0x45
+GYRO_ZOUT = 0x47
+PWR_MGMT_1 = 0x6b
+PWR_MGMT_2 = 0x6c
+
 class Mpu6050:
 
     def __init__(self):
-        self.DEV_ADDR = 0x68 #https://shizenkarasuzon.hatenablog.com/entry/2019/03/06/114248
-        self.ACCEL_XOUT = 0x3b
-        self.ACCEL_YOUT = 0x3d
-        self.ACCEL_ZOUT = 0x3f
-        self.TEMP_OUT = 0x41
-        self.GYRO_XOUT = 0x43
-        self.GYRO_YOUT = 0x45
-        self.GYRO_ZOUT = 0x47
-        self.PWR_MGMT_1 = 0x6b
-        self.PWR_MGMT_2 = 0x6c
         self.bus = SMBus(1)
-        self.bus.write_byte_data(self.DEV_ADDR, self.PWR_MGMT_1, 0)
+        self.bus.write_byte_data(DEV_ADDR, PWR_MGMT_1, 0)
 
     def __read_word(self, adr):
-        high = self.bus.read_byte_data(self.DEV_ADDR, adr)
-        low  = self.bus.read_byte_data(self.DEV_ADDR, adr+1)
+        high = self.bus.read_byte_data(DEV_ADDR, adr)
+        low  = self.bus.read_byte_data(DEV_ADDR, adr+1)
         val  = (high << 8) + low
         return val
 
@@ -32,28 +33,28 @@ class Mpu6050:
 
     #角速度(ジャイロ)データ取得
     def __get_gyro_data_lsb(self):
-        self.x = self.__read_word_sensor(self.GYRO_XOUT)
-        self.y = self.__read_word_sensor(self.GYRO_YOUT)
-        self.z = self.__read_word_sensor(self.GYRO_ZOUT)
-        return [self.x, self.y, self.z]
+        x_gyro = self.__read_word_sensor(GYRO_XOUT)
+        y_gyro = self.__read_word_sensor(GYRO_YOUT)
+        z_gyro = self.__read_word_sensor(GYRO_ZOUT)
+        return [x_gyro, y_gyro, z_gyro]
 
     def get_gyro_data_deg(self):
-        x,y,z = self.__get_gyro_data_lsb()
-        x = self.x / 1310
-        y = self.y / 1310
-        z = self.z / 1310
-        return [x, y, z]
+        x_gyro,y_gyro,z_gyro = self.__get_gyro_data_lsb()
+        x_gyro /= 1310
+        y_gyro /= 1310
+        z_gyro /= 1310
+        return [x_gyro, y_gyro, z_gyro]
 
     #加速度データ取得
     def __get_accel_data_lsb(self):
-        self.x = self.__read_word_sensor(self.ACCEL_XOUT)
-        self.y = self.__read_word_sensor(self.ACCEL_YOUT)
-        self.z = self.__read_word_sensor(self.ACCEL_ZOUT)
-        return [self.x, self.y, self.z]
+        x_accel = self.__read_word_sensor(ACCEL_XOUT)
+        y_accel = self.__read_word_sensor(ACCEL_YOUT)
+        z_accel = self.__read_word_sensor(ACCEL_ZOUT)
+        return [x_accel, y_accel, z_accel]
 
     def get_accel_data_g(self):
-        x,y,z = self.__get_accel_data_lsb()
-        x = self.x / 16384.0
-        y = self.y / 16384.0
-        z = self.z / 16384.0
-        return [x, y, z]
+        x_accel,y_accel,z_accel = self.__get_accel_data_lsb()
+        x_accel /= 16384.0
+        y_accel /= 16384.0
+        z_accel /= 16384.0
+        return [x_accel, y_accel, z_accel]

--- a/mpu6050.py
+++ b/mpu6050.py
@@ -32,7 +32,7 @@ class Mpu6050:
         else:
             return val
 
-    #角速度(ジャイロ)データ取得
+    #角速度(rad/msec)取得
     def __load_gyro_sensor(self):
         x_gyro = self.__read_word_sensor(GYRO_XOUT)
         y_gyro = self.__read_word_sensor(GYRO_YOUT)
@@ -46,7 +46,7 @@ class Mpu6050:
         z_gyro /= 131000
         return [x_gyro, y_gyro, z_gyro]
 
-    #加速度データ取得
+    #加速度(m/msec)取得
     def __load_accelerometer(self):
         x_accel = self.__read_word_sensor(ACCEL_XOUT)
         y_accel = self.__read_word_sensor(ACCEL_YOUT)

--- a/mpu6050.py
+++ b/mpu6050.py
@@ -1,7 +1,8 @@
 from smbus import SMBus
 
 
-DEV_ADDR = 0x68 #https://shizenkarasuzon.hatenablog.com/entry/2019/03/06/114248
+# ref: https://shizenkarasuzon.hatenablog.com/entry/2019/03/06/114248
+DEV_ADDR = 0x68
 ACCEL_XOUT = 0x3b
 ACCEL_YOUT = 0x3d
 ACCEL_ZOUT = 0x3f

--- a/servo.py
+++ b/servo.py
@@ -10,7 +10,8 @@ class ServoController:
         self.pi.set_mode(self.mPin, pigpio.OUTPUT)
 
     def set_position(self, degree):
-        duty = int(((12-2.5)/180*degree+2.5)*10000) #https://github.com/kure-kosen-water-rocket/rocket_attitude_control/issues/2
+        # ref: https://github.com/kure-kosen-water-rocket/rocket_attitude_control/issues/2
+        duty = int(((12-2.5)/180*degree+2.5)*10000)
         self.pi.hardware_PWM(self.mPin, 50, duty)
 
     def clean_up(self):

--- a/servo.py
+++ b/servo.py
@@ -1,0 +1,20 @@
+import time
+import pigpio
+from pigpio import pi
+
+
+class ServoController:
+    def __init__(self, Pin):
+        self.pi = pi()
+        self.mPin = Pin
+        self.pi.set_mode(self.mPin, pigpio.OUTPUT)
+
+    def set_position(self, degree):
+        duty = int(((12-2.5)/180*degree+2.5)*10000) #issue番号(#2)を参照
+        self.pi.hardware_PWM(self.mPin, 50, duty)
+
+    def cleanup_gpio(self):
+        self.pi.hardware_PWM(self.mPin, 50, 0)
+        time.sleep(1)
+        self.pi.set_mode(self.mPin, pigpio.INPUT)
+        self.pi.stop()

--- a/servo.py
+++ b/servo.py
@@ -4,16 +4,16 @@ from pigpio import pi
 
 
 class ServoController:
-    def __init__(self, Pin):
+    def __init__(self, Pin): #BCM番号ではなく物理的なpin番号
         self.pi = pi()
         self.mPin = Pin
         self.pi.set_mode(self.mPin, pigpio.OUTPUT)
 
     def set_position(self, degree):
-        duty = int(((12-2.5)/180*degree+2.5)*10000) #issue番号(#2)を参照
+        duty = int(((12-2.5)/180*degree+2.5)*10000) #https://github.com/kure-kosen-water-rocket/rocket_attitude_control/issues/2
         self.pi.hardware_PWM(self.mPin, 50, duty)
 
-    def cleanup_gpio(self):
+    def clean_up(self):
         self.pi.hardware_PWM(self.mPin, 50, 0)
         time.sleep(1)
         self.pi.set_mode(self.mPin, pigpio.INPUT)

--- a/servo.py
+++ b/servo.py
@@ -3,13 +3,13 @@ import pigpio
 
 
 class ServoController:
-    def __init__(self, Pin): #BCM番号ではなく物理的なpin番号
+    def __init__(self, Pin):  # BCM番号ではなく物理的なpin番号
         self.pi = pigpio.pi()
         self.mPin = Pin
         self.pi.set_mode(self.mPin, pigpio.OUTPUT)
 
     def set_position(self, degree):
-         # ref: https://github.com/kure-kosen-water-rocket/rocket_attitude_control/issues/2
+        # ref: https://github.com/kure-kosen-water-rocket/rocket_attitude_control/issues/2
         duty = int(((12-2.5)/180*degree+2.5)*10000)
         self.pi.hardware_PWM(self.mPin, 50, duty)
 

--- a/servo.py
+++ b/servo.py
@@ -1,11 +1,10 @@
 import time
 import pigpio
-from pigpio import pi
 
 
 class ServoController:
     def __init__(self, Pin): #BCM番号ではなく物理的なpin番号
-        self.pi = pi()
+        self.pi = pigpio.pi()
         self.mPin = Pin
         self.pi.set_mode(self.mPin, pigpio.OUTPUT)
 

--- a/servo.py
+++ b/servo.py
@@ -10,7 +10,8 @@ class ServoController:
         self.pi.set_mode(self.mPin, pigpio.OUTPUT)
 
     def set_position(self, degree):
-        duty = int(((12-2.5)/180*degree+2.5)*10000) #https://github.com/kure-kosen-water-rocket/rocket_attitude_control/issues/2
+         # ref: https://github.com/kure-kosen-water-rocket/rocket_attitude_control/issues/2
+        duty = int(((12-2.5)/180*degree+2.5)*10000)
         self.pi.hardware_PWM(self.mPin, 50, duty)
 
     def clean_up(self):


### PR DESCRIPTION
- Quaternion が重かったので相補フィルターを使用した角度の算出方法に変更しました。
- 相補フィルターは加速度の値が大きくなればなるほど加速度側から得られる角度の比重を小さくしないと誤差が大きくなってしまうので[ジャイロと加速度の値を加速度の大きさによって変化](https://garchiving.com/gyro-drift-part2/)させるようにしました。
- 上のおかげで静止時のドリフトも消えました！！
- forにかかる時間を微小時間dtとして扱うことでより正確な計算が出来るように努力しました。
- コードのいらない部分を削除しました(役割が似ていた変数の統一などなど...)
- (追記)[アドレス周りの参考リンク](https://shizenkarasuzon.hatenablog.com/entry/2019/03/06/114248)です